### PR TITLE
only provide the built-in library manager option

### DIFF
--- a/docs/device/arduino-quickstart.mdx
+++ b/docs/device/arduino-quickstart.mdx
@@ -70,9 +70,9 @@ Download and install the latest version of <a href="https://www.arduino.cc/en/Ma
  
 <a href="https://github.com/stm32duino/wiki/wiki/Getting-Started" target="_blank">Instructions to add STM32 board support to Arduino</a> 
 
-## Install LongFi Library with Arduino IDE 
+## Install LongFi Library
  
-The LongFi Arduino Library may be installed from the IDE. 
+The LongFi library may be installed from the Arduino IDE (if you prefer to clone it via git, [go here](https://github.com/helium/longfi-arduino#install-library-with-git).
 
 Arduino IDE:
 
@@ -83,22 +83,6 @@ Sketch -> Include Libraries -> Manage Libraries
 Search for `LongFi` and install the latest version 
 
 <img src={Arduino_LongFi} /> 
-
-## Install LongFi Arduino Library using Git 
- 
-Clone the longfi-arduino repository by using the following command ... 
-
-```
-git clone git@github.com:helium/longfi-arduino.git
-```
-
-... to the following directory:
- 
-```
-linux: /home/{user}/Arduino/libraries
-windows: Documents/Arduino/libraries
-mac os: Documents/Arduino/libraries
-```
 
 Then restart your Arduino IDE to load the library. 
 


### PR DESCRIPTION
I would just provide the "easy" path and provide the link for the ambitious. If you maintain both, make the "OR" between these two approaches more clear.