### PR TITLE
US downlink ch.0 was wrong

### DIFF
--- a/longfi/regional-channels.md
+++ b/longfi/regional-channels.md
@@ -52,7 +52,7 @@ Max application payload is given assuming the absence of the optional FOpt MAC C
 
 | Channel | Frequency \(MHz\) |
 | :--- | :--- |
-| 0 | 922.3 |
+| 0 | 923.3 |
 | 1 | 923.9 |
 | 2 | 924.5 |
 | 3 | 925.1 |


### PR DESCRIPTION
It should be 923.3MHz, not 922.3MHz, for channel 0 downlink frequency.

See TTN freqs: https://www.thethingsnetwork.org/docs/lorawan/frequency-plans.html

See also LoRaWAN alliance page 29: https://lora-alliance.org/sites/default/files/2020-01/rp_2-1.0.0_final_release.pdf

Also, was this error made in the backend Helium router itself?