### PR TITLE
For the 500kHz channels, only use 904.6MHz

### DIFF
--- a/devices/arduino-quickstart/heltec-wifi-lora-32-v2.md
+++ b/devices/arduino-quickstart/heltec-wifi-lora-32-v2.md
@@ -199,7 +199,7 @@ channelsMaskTemp[0] = 0xFF00;
 channelsMaskTemp[1] = 0x0000;
 channelsMaskTemp[2] = 0x0000;
 channelsMaskTemp[3] = 0x0000;
-channelsMaskTemp[4] = 0x0000;
+channelsMaskTemp[4] = 0x0002;
 channelsMaskTemp[5] = 0x0000;
 ```
 


### PR DESCRIPTION
0x0002 in this place will make it only use 904.6MHz. Don't transmit on any of the other 500kHz channels, nothing will be listening there!