### PR TITLE
Add notice to verify Heltec runtime for Data Rate setting

### DIFF
--- a/devices/arduino-quickstart/heltec-cubecell-board.md
+++ b/devices/arduino-quickstart/heltec-cubecell-board.md
@@ -164,7 +164,7 @@ We're finally ready to upload our sketch to the board. In the Arduino IDE, click
 If you are using the HTCC-AB02S board with a sketch that is GPS enabled but find the device is unable to obtain a GPS lock you can try changing the GPS data satellite source via the GPS class Air530.setMode() API. Add the Air530.setmode() to the setup() method of your sketch.
 ```text
 // MODE_GPS - US,
-// MODE_GPS_BEIOU - Chinese - This is the default
+// MODE_GPS_BEIDOU - Chinese - This is the default
 // MODE_GPS_GLONASS - Russian
 // set what works best for your connectivity, for example: 
 Air530.setmode(MODE_GPS);

--- a/devices/arduino-quickstart/heltec-cubecell-board.md
+++ b/devices/arduino-quickstart/heltec-cubecell-board.md
@@ -123,7 +123,12 @@ Find Directions on Heltec's website [here](https://heltec-automation-docs.readth
 
 Arduino IDE:
 
-1. Select Tools -&gt; Board: -&gt;CubeCell-Board
+If you are using the HTCC-AB02 flavor of Heltec board 
+1. Select Tools -&gt; Board: -&gt;CubeCell-Board (HTCC-AB02)
+
+If you are using the HTCC-AB02S GPS enabled flavor of Heltec board
+1. Select Tools -&gt; Board: -&gt;CubeCell-GPS (HTCC-AB02S)
+
 
 ### Select Region
 
@@ -154,6 +159,16 @@ At the top of the sketch, replace the three **FILL\_ME\_IN** fields, with the ma
 We're finally ready to upload our sketch to the board. In the Arduino IDE, click the right arrow button, or navigate to \(**Sketch &gt; Upload\),** to build and upload your new firmware to the board. You should see something similar to the image below at the bottom of your Arduino IDE, when the upload is successful.
 
 ![](../../.gitbook/assets/cubecell-arduino-upload.png)
+
+### Using HTCC-AB02S Board With GPS Capable Sketch <a id="HTCC-AB02S-with-GPS"></a>
+If you are using the HTCC-AB02S board with a sketch that is GPS enabled but find the device is unable to obtain a GPS lock you can try changing the GPS data satellite source via the GPS class Air530.setMode() API. Add the Air530.setmode() to the setup() method of your sketch.
+```text
+// MODE_GPS - US,
+// MODE_GPS_BEIOU - Chinese - This is the default
+// MODE_GPS_GLONASS - Russian
+// set what works best for your connectivity, for example: 
+Air530.setmode(MODE_GPS);
+```
 
 ### Viewing Serial Output <a id="viewing-serial-output"></a>
 

--- a/devices/arduino-quickstart/heltec-cubecell-board.md
+++ b/devices/arduino-quickstart/heltec-cubecell-board.md
@@ -81,6 +81,40 @@ Next, to install this board support package:
 
 ![](../../.gitbook/assets/cubecell-board-support-search.png)
 
+### Manual updates to the Heltec runtime libraries
+
+Some versions of Heltec's runtime libraries have set a default configuration variable to a value that is incompatible with the Helium network, especially when the Heltec device is configured for the North American market. Before attempting to use the libraries it is best to verify the value of the variable.
+
+The top level location of the file of interest depends on the library installation directory of the IDE you are using, Arduino IDE vs Platformio IDE, as well as the host platform, Windows vs Linux vs Mac. With the Arduino IDE location, the library version number may also be different depending on when you download the package.
+
+For example on a Linux platform the files should be located at:
+
+- Arduino IDE library version 1.0.0:  ~/.arduino15/packages/CubeCell/hardware/CubeCell/1.0.0/libraries/LoRa/src/LoRaWan_APP.cpp
+
+- Platformio IDE: ~/.platformio/packages/framework-arduinoasrmicro650x/libraries/LoRa/src/LoRaWan_APP.cpp
+
+In LoRaWan_APP.cpp look for #define LORAWAN_DEFAULT_DATARATE  
+Depending on the version of the Heltec runtime that is installed this default may be set to DR_0, DR_3, DR_5 or some other value.
+Note: DR_5 is not valid for US915, the North American market.
+
+The LORAWAN_DEFAULT_DATARATE setting is tied directly to the maximum size of the data packet you are transferring. While other runtime versions may allow programatic overide of this default, the Heltec implementation does not currently support overriding.
+
+NOTE: If you try to transfer a packet that is larger than this setting allows, your device may well successfully join the network but the data transmit will fail silently. Hopefully a future release will give the application layer failure notification.
+
+|Data Rate (DR)  |    Max Application Payload|
+-----------------|--------------------------|
+|DR_0            |     11 bytes             |
+|DR_1            |     53 bytes             |
+|DR_2            |     125 bytes            |
+|DR_3            |     242 bytes            | 
+|DR_4            |     242 bytes            | 
+|DR_5 - 7        |     Not Valid            |
+
+Update the LORAWAN_DEFAULT_DATARATE as appropriate for your application needs.
+
+The above values are valid for the US902-928MHz region(North America), the values may differ for other LoRa regions. This link will take you to document which may help determine the correct value for other LoRa regions.
+https://lora-alliance.org/resource-hub/rp2-101-lorawanr-regional-parameters
+
 ### Install Serial Driver
 
 Find Directions on Heltec's website [here](https://heltec-automation-docs.readthedocs.io/en/latest/general/establish_serial_connection.html).


### PR DESCRIPTION
As it stands version 1.0.0 of the Heltec libs set the default data rate to DR_5 which is not valid for US915, North America. This is a description about how to reset it.

We should update this with a link to a longer discussion of Data Rate, Spreading factor, transmit power and I guess other developer considerations,  once we have that figured out.
