### PR TITLE
Remove reference to console beta that has ended on console quickstart guide.

### DIFF
--- a/console/quickstart.md
+++ b/console/quickstart.md
@@ -10,7 +10,7 @@ This Console quickstart guide will cover how to:
 * Add a device to Helium Console and record device details 
 
 {% hint style="info" %}
-The cost per packet is $0.00001 USD \(24 byte packets\) which is equivalent to 1 Data Credit \(DC\). During the beta there is no cost to send packets. For more information please go here.
+The cost per packet is $0.00001 USD \(24 byte packets\) which is equivalent to 1 Data Credit \(DC\). For more information please go [here](../longfi/data-credits).
 {% endhint %}
 
 ## Create an account


### PR DESCRIPTION
Console quickstart guide references free data during beta period which is over. Added link to data credits page. Addresses #150 