### PR TITLE
Update heltec-cubecell-board.md

### DIFF
--- a/devices/arduino-quickstart/heltec-cubecell-board.md
+++ b/devices/arduino-quickstart/heltec-cubecell-board.md
@@ -141,7 +141,7 @@ Platformio IDE:
 ~/.platformio/packages/framework-arduinoasrmicro650x/cores/asr650x/loramac/mac/region/RegionUS915.c
 ```
 
-In this file the line: \( your version could have 14 or 16 for the 7th parameter, it needs to be 8\)
+In this file locate the line below, the 7th parameter which might be 14 should be changed to either 8 or 16. Either value will work. Later versions of the runtime may have this value set to 14 which should work just fine. 
 
 Change:
 


### PR DESCRIPTION
Minor update to the section that updates a runtime library value. It was thought a value (16) was incorrect, but in fact it is fine. 
 Not pulling this in only results in the user perhaps changing a value unnecessarily.