### PR TITLE
update doc. to use Helium packet_forwarder..

### DIFF
--- a/hotspot/developer-setup.md
+++ b/hotspot/developer-setup.md
@@ -42,11 +42,11 @@ This guide is experimental and for advanced users only, and you may run in to va
 
 ## Example Custom Hardware
 
-Any hardware that can run an 8 channel LoRa front-end \(such as SX1301 or SX1302\) and send and receive packets using the [Semtech UDP Protocol](https://github.com/Lora-net/packet_forwarder/blob/master/PROTOCOL.TXT) can be used to participate in the Helium Network.
+Any hardware that can run an 8 channel LoRa front-end \(such as SX1301 or SX1302\) and send and receive packets using the [Semtech UDP Protocol](https://github.com/helium/packet_forwarder/blob/master/PROTOCOL.TXT) can be used to participate in the Helium Network.
 
 If you don’t have your own hardware yet, we recommend using a[ Raspberry Pi 3B+ or 4B](https://www.raspberrypi.org/) running the latest[ Raspian Buster](https://www.raspberrypi.org/downloads/raspbian/) image with a[ RAK2245 Pi Hat](https://store.rakwireless.com/products/rak2245-pi-hat) installed, and a recommended 64GB SD card.
 
-If you already have hardware, we may just have a guide for [your LoRaWAN Hotspot](lorawan-gateway-migration/) already. In general, it is possible to use any LoRa gateway that can run Semtech's [packet forwarder](https://github.com/Lora-net/packet_forwarder) application and run the `miner` application on a separate host.
+If you already have hardware, we may just have a guide for [your LoRaWAN Hotspot](lorawan-gateway-migration/) already. In general, it is possible to use any LoRa gateway that can run Semtech's [packet forwarder](https://github.com/helium/packet_forwarder) application and run the `miner` application on a separate host.
 
 This README will assume a Raspberry Pi 3B+/4 with 1GB RAM + RAK2245 combination described above. This combination is available as a packaged product directly from RAK called the [Pilot Gateway](https://store.rakwireless.com/products/rak7243c-pilot-gateway?variant=26682434879588).
 
@@ -104,9 +104,9 @@ Now let's go ahead and update our install with:
 sudo apt-get update
 ```
 
-## Installing the Semtech packet forwarder
+## Installing the Helium packet forwarder
 
-Once you have miner running, you'll need the Semtech packet forwarder to receive packets via SPI and the RAK2245 board and deliver them to the miner via UDP.
+Once you have miner running, you'll need the Helium packet forwarder to receive packets via SPI and the RAK2245 board and deliver them to the miner via UDP. The Helium packet forwarder is based on the Semtech packet forwarder with Helium changes.
 
 You may need to install git:
 
@@ -118,8 +118,8 @@ Clone the git repository:
 
 ```text
 $ cd ~
-$ git clone https://github.com/Lora-net/packet_forwarder
-$ git clone https://github.com/Lora-net/lora_gateway
+$ git clone https://github.com/helium/packet_forwarder
+$ git clone https://github.com/helium/lora_gateway
 ```
 
 We'll then need to replace the existing packet forwarder configuration file with a Helium-specific version:


### PR DESCRIPTION
The Helium code is based on the Semtech packet forwarder with changes.

Update docs to reference the Helium packet forwarder. As it is the supported version.